### PR TITLE
Add buildx process to build and push images for amd64 and arm64 platforms

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,5 +6,9 @@ set -euo pipefail
 DEFAULT_TAG=naushadh/hive-metastore:latest
 TAG=${TAG:-$DEFAULT_TAG}
 
-docker build --tag "$TAG" .
-docker push "$TAG"
+docker buildx create --name multiarch --use
+
+docker buildx build --push \
+    --platform linux/arm64,linux/amd64 \
+    --tag "$TAG" \
+    .

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 DEFAULT_TAG=naushadh/hive-metastore:latest
 TAG=${TAG:-$DEFAULT_TAG}
 
-docker buildx create --name multiarch --use
+docker buildx ls | grep multiarch || docker buildx create --name multiarch --use
 
 docker buildx build --push \
     --platform linux/arm64,linux/amd64 \


### PR DESCRIPTION
Hi there,

I recently tried your `hive-metastore` image and really enjoyed how simple it was to deploy. I am hoping to leverage it in my repository, [jefflester/minitrino](https://github.com/jefflester/minitrino), but many of the users that use my tool run it on MacBook Pros with Apple's ARM64 CPUs. 

This image's native platform is AMD64, so if you're a user running on ARM64, the image runs under emulation. While running under emulation, performance can take a noticeable hit, especially when running queries against tables containing lots of partitions and/or files.

This PR adds a `buildx` command to the release script that pushes images for both architectures. For the time being, I have pushed my own multi-platform build, but would be happy to revert to your Dockerhub repository if this gets merged. 

Thanks for considering, and please let me know if you have any questions.